### PR TITLE
Do not return unapproved properties when getting all properties

### DIFF
--- a/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
+++ b/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
@@ -108,6 +108,11 @@ public class PropertySpecification implements Specification<Property> {
             predicate = criteriaBuilder.and(predicate, amenitiesPredicate);
         }
 
+        if (filter.getApproved() != null) {
+            Predicate typePredicate = criteriaBuilder.equal(root.get("approved"), filter.getApproved());
+            predicate = criteriaBuilder.and(predicate, typePredicate);
+        }
+
         return predicate;
     }
 


### PR DESCRIPTION
This PR adds a check of the `approved` field to `PropertySpecification` so as not to return unapproved properties when getting all properties in `PropertyController.getAll`. 