### PR TITLE
Host review notifications 7.5

### DIFF
--- a/src/main/java/com/lunark/lunark/auth/model/Account.java
+++ b/src/main/java/com/lunark/lunark/auth/model/Account.java
@@ -47,6 +47,11 @@ public class Account implements UserDetails {
     private ProfileImage profileImage;
 
     @OneToMany(cascade = CascadeType.ALL)
+    @JoinTable(
+            name="account_reviews",
+            joinColumns = {@JoinColumn(name = "account_id")},
+            inverseJoinColumns = {@JoinColumn(name = "reviews_id")}
+    )
     private Collection<Review> reviews;
     @ManyToMany
     private Set<Property> favoriteProperties;

--- a/src/main/java/com/lunark/lunark/notifications/service/INotificationService.java
+++ b/src/main/java/com/lunark/lunark/notifications/service/INotificationService.java
@@ -1,8 +1,9 @@
 package com.lunark.lunark.notifications.service;
 
+import com.lunark.lunark.auth.model.Account;
 import com.lunark.lunark.notifications.model.Notification;
 import com.lunark.lunark.properties.model.Property;
-import org.springframework.stereotype.Service;
+import com.lunark.lunark.reviews.model.Review;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -11,7 +12,7 @@ public interface INotificationService {
     Collection<Notification> getAllNotifications(Long accountId);
     Notification create(Notification notification);
 
-    Notification createPropertyReviewNotification(Property property);
+    Notification createNotification(Review review);
 
     long getUnreadNotificationCount(String email);
     void subscribe(ISubscriber subscriber);

--- a/src/main/java/com/lunark/lunark/notifications/service/NotificationService.java
+++ b/src/main/java/com/lunark/lunark/notifications/service/NotificationService.java
@@ -1,9 +1,11 @@
 package com.lunark.lunark.notifications.service;
 
+import com.lunark.lunark.auth.model.Account;
 import com.lunark.lunark.notifications.model.Notification;
 import com.lunark.lunark.notifications.model.NotificationType;
 import com.lunark.lunark.notifications.repository.INotificationRepository;
 import com.lunark.lunark.properties.model.Property;
+import com.lunark.lunark.reviews.model.Review;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -50,15 +52,22 @@ public class NotificationService implements INotificationService {
         // TODO: Check if notification should be sent based on the notification settings of the recipient and type of notification
         return true;
     }
-
     @Override
-    public Notification createPropertyReviewNotification(Property property) {
+    public Notification createNotification(Review review)  {
+        String message = createReviewNotificationMessage(review);
         Notification notification = new Notification(
-                "New property review for " + property.getName(),
+                message,
                 ZonedDateTime.now(clock),
-                NotificationType.PROPERTY_REVIEW,
-                property.getHost());
+                review.getType().equals(Review.ReviewType.PROPERTY) ? NotificationType.PROPERTY_REVIEW : NotificationType.HOST_REVIEW,
+                review.getType().equals(Review.ReviewType.PROPERTY)? review.getProperty().getHost() : review.getHost());
         return this.create(notification);
+    }
+
+    private String createReviewNotificationMessage(Review review) {
+        if (review.getType().equals(Review.ReviewType.HOST)) {
+            return "New host review";
+        }
+        return "New property review for " + review.getProperty().getName();
     }
 
     @Override
@@ -81,4 +90,5 @@ public class NotificationService implements INotificationService {
     public Optional<Notification> findById(Long id) {
         return this.notificationRepository.findById(id);
     }
+
 }

--- a/src/main/java/com/lunark/lunark/properties/model/Property.java
+++ b/src/main/java/com/lunark/lunark/properties/model/Property.java
@@ -73,6 +73,11 @@ public class Property {
             cascade = CascadeType.ALL,
             orphanRemoval = true
     )
+    @JoinTable(
+            name = "property_reviews",
+            joinColumns = {@JoinColumn(name = "property_id")},
+            inverseJoinColumns = {@JoinColumn(name = "reviews_id")}
+    )
     private Collection<Review> reviews = new ArrayList<>();
     @OneToMany(
             cascade = CascadeType.ALL,

--- a/src/main/java/com/lunark/lunark/reviews/controller/ReviewController.java
+++ b/src/main/java/com/lunark/lunark/reviews/controller/ReviewController.java
@@ -134,9 +134,7 @@ public class ReviewController {
         }
 
         try {
-            Review reviewToApprove = existingReview.get();
-            reviewToApprove.setApproved(true);
-            Review approvedReview = reviewService.update(existingReview.get());
+            Review approvedReview = this.reviewService.approveReview(existingReview.get());
             return new ResponseEntity<>(modelMapper.map(approvedReview, ReviewApprovalDto.class), HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/lunark/lunark/reviews/controller/ReviewController.java
+++ b/src/main/java/com/lunark/lunark/reviews/controller/ReviewController.java
@@ -35,13 +35,13 @@ public class ReviewController {
     Clock clock;
 
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Review> getReview(@PathVariable("id") Long id) {
+    public ResponseEntity<ReviewDto> getReview(@PathVariable("id") Long id) {
         Optional<Review> review = reviewService.find(id);
         if (review.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
-        return new ResponseEntity<>(review.get(), HttpStatus.OK);
+        return new ResponseEntity<ReviewDto>(ReviewDtoMapper.toDto(review.get()), HttpStatus.OK);
     }
 
     @GetMapping(value = "/host/{id}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/lunark/lunark/reviews/model/Review.java
+++ b/src/main/java/com/lunark/lunark/reviews/model/Review.java
@@ -1,6 +1,7 @@
 package com.lunark.lunark.reviews.model;
 
 import com.lunark.lunark.auth.model.Account;
+import com.lunark.lunark.properties.model.Property;
 import jakarta.persistence.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -32,6 +33,22 @@ public class Review {
 
     @Column(name = "deleted", columnDefinition = "boolean default false")
     private boolean deleted = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinTable(
+            name="account_reviews",
+            joinColumns = {@JoinColumn(name = "reviews_id")},
+            inverseJoinColumns = {@JoinColumn(name = "account_id")}
+    )
+    @Transient
+    private Account host;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "property_reviews",
+            joinColumns = {@JoinColumn(name = "reviews_id")},
+            inverseJoinColumns = {@JoinColumn(name = "property_id")}
+    )
+    private Property property;
 
     public Review() {
 
@@ -105,5 +122,33 @@ public class Review {
 
     public void setAuthor(Account author) {
         this.author = author;
+    }
+
+    public Account getHost() {
+        if (this.type != ReviewType.HOST) {
+            throw new IllegalStateException("Cannot get host for non-host reviews");
+        }
+        return host;
+    }
+
+    public void setHost(Account host) {
+        if (this.type != ReviewType.HOST) {
+            throw new IllegalStateException("Cannot set host for non-host reviews");
+        }
+        this.host = host;
+    }
+
+    public Property getProperty() {
+        if (this.type != ReviewType.PROPERTY) {
+            throw new IllegalStateException("Cannot get property for non-property reviews");
+        }
+        return property;
+    }
+
+    public void setProperty(Property property) {
+        if (this.type != ReviewType.PROPERTY) {
+            throw new IllegalStateException("Cannot set property for non-property reviews");
+        }
+        this.property = property;
     }
 }

--- a/src/main/java/com/lunark/lunark/reviews/model/Review.java
+++ b/src/main/java/com/lunark/lunark/reviews/model/Review.java
@@ -40,7 +40,6 @@ public class Review {
             joinColumns = {@JoinColumn(name = "reviews_id")},
             inverseJoinColumns = {@JoinColumn(name = "account_id")}
     )
-    @Transient
     private Account host;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinTable(

--- a/src/main/java/com/lunark/lunark/reviews/service/IReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/IReviewService.java
@@ -17,4 +17,6 @@ public interface IReviewService<Review> {
     boolean guestEligibleToReviewHost(Long guestId, Long hostId);
 
     Collection<com.lunark.lunark.reviews.model.Review> findAllUnapproved();
+
+    com.lunark.lunark.reviews.model.Review approveReview(com.lunark.lunark.reviews.model.Review review);
 }

--- a/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
@@ -127,4 +127,11 @@ public class ReviewService implements IReviewService<Review> {
     public Collection<Review> findAllUnapproved() {
         return this.reviewRepository.findAllByApproved(false);
     }
+
+    @Override
+    public Review approveReview(Review review) {
+        review.setApproved(true);
+        Review approvedReview = this.update(review);
+        return approvedReview;
+    }
 }

--- a/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
@@ -74,8 +74,8 @@ public class ReviewService implements IReviewService<Review> {
             throw new RuntimeException("Review author not eligible to review host");
         }
         host.getReviews().add(review);
-        review.setHost(host);
         this.accountService.update(host);
+        review.setHost(host);
         return review;
     }
 

--- a/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
@@ -77,6 +77,7 @@ public class ReviewService implements IReviewService<Review> {
         host.getReviews().add(review);
         review.setHost(host);
         this.accountService.update(host);
+        this.notificationService.createNotification(review);
         return review;
     }
 

--- a/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
@@ -62,7 +62,8 @@ public class ReviewService implements IReviewService<Review> {
         Property property = this.propertyRepository.findById(propertyId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Property not found"));
         property.getReviews().add(review);
         this.propertyRepository.saveAndFlush(property);
-        this.notificationService.createPropertyReviewNotification(property);
+        review.setProperty(property);
+        this.notificationService.createNotification(review);
         return review;
     }
 
@@ -74,6 +75,7 @@ public class ReviewService implements IReviewService<Review> {
             throw new RuntimeException("Review author not eligible to review host");
         }
         host.getReviews().add(review);
+        review.setHost(host);
         this.accountService.update(host);
         return review;
     }

--- a/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
@@ -63,7 +63,6 @@ public class ReviewService implements IReviewService<Review> {
         property.getReviews().add(review);
         this.propertyRepository.saveAndFlush(property);
         review.setProperty(property);
-        this.notificationService.createNotification(review);
         return review;
     }
 
@@ -77,7 +76,6 @@ public class ReviewService implements IReviewService<Review> {
         host.getReviews().add(review);
         review.setHost(host);
         this.accountService.update(host);
-        this.notificationService.createNotification(review);
         return review;
     }
 
@@ -133,6 +131,7 @@ public class ReviewService implements IReviewService<Review> {
     public Review approveReview(Review review) {
         review.setApproved(true);
         Review approvedReview = this.update(review);
+        this.notificationService.createNotification(review);
         return approvedReview;
     }
 }

--- a/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
+++ b/src/main/java/com/lunark/lunark/reviews/service/ReviewService.java
@@ -60,23 +60,21 @@ public class ReviewService implements IReviewService<Review> {
     @Override
     public Review createPropertyReview(Review review, Long propertyId) {
         Property property = this.propertyRepository.findById(propertyId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Property not found"));
-        property.getReviews().add(review);
-        this.propertyRepository.saveAndFlush(property);
+        if (!this.guestEligibleToReviewProperty(review.getAuthor().getId(), propertyId)) {
+            throw new RuntimeException("Review author not eligible to review property");
+        }
         review.setProperty(property);
-        return review;
+        return reviewRepository.saveAndFlush(review);
     }
 
     @Override
     public Review createHostReview(Review review, Long hostId) {
-        //TODO: Create host reveiews
         Account host = this.accountService.find(hostId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Host not found"));
         if (!this.guestEligibleToReviewHost(review.getAuthor().getId(), hostId)) {
             throw new RuntimeException("Review author not eligible to review host");
         }
-        host.getReviews().add(review);
-        this.accountService.update(host);
         review.setHost(host);
-        return review;
+        return reviewRepository.saveAndFlush(review);
     }
 
     @Override


### PR DESCRIPTION
This PR enables the backend to send notifications when a host review is approved.
This PR also changes property review notifications so that they are sent when a review is approved instead of uploaded.  