### PR TITLE
Don't block off availability entires after the end date of an acccepted reservation as reserved

### DIFF
--- a/src/main/java/com/lunark/lunark/reservations/service/ReservationService.java
+++ b/src/main/java/com/lunark/lunark/reservations/service/ReservationService.java
@@ -192,7 +192,7 @@ public class ReservationService implements IReservationService {
 
         for(PropertyAvailabilityEntry entry: property.getAvailabilityEntries())  {
             LocalDate entryDate = entry.getDate();
-            if(!entryDate.isBefore(startDate) && !entryDate.isAfter(entryDate)) {
+            if(!entryDate.isBefore(startDate) && !entryDate.isAfter(endDate)) {
                 entry.setReserved(isrReserved);
             }
 


### PR DESCRIPTION
This PR fixes a typo in `ReservationService.updatePropertyAvailability` that caused the bug described in the title of this PR.