### PR TITLE
Fix ids of filtered reservations being `undefined` on the frontend

### DIFF
--- a/src/main/java/com/lunark/lunark/reservations/dto/ReservationResponseDto.java
+++ b/src/main/java/com/lunark/lunark/reservations/dto/ReservationResponseDto.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReservationResponseDto {
+    Long id;
     PropertyResponseDto property;
     LocalDate startDate;
     LocalDate endDate;


### PR DESCRIPTION
The `api/reservations/current` endpoint does not send the ids of filtered reservation. As a result, the frontend cannot accept or decline reservations that arrive through that endpoint.
This PR adds an `id` field to `ReservationResponseDto`, which is returned by the aforementioned endpoint.