### PR TITLE
Read host id from authentication token when creating and updating properties

### DIFF
--- a/src/main/java/com/lunark/lunark/mapper/PropertyDtoMapper.java
+++ b/src/main/java/com/lunark/lunark/mapper/PropertyDtoMapper.java
@@ -52,6 +52,11 @@ public class PropertyDtoMapper {
         return property;
     }
 
+    public Property fromDtoToProperty(PropertyRequestDto propertyRequestDto, Long hostId) {
+        propertyRequestDto.setHostId(hostId);
+        return this.fromDtoToProperty(propertyRequestDto);
+    }
+
     public static PropertyResponseDto fromPropertyToDto(Property property) {
         PropertyResponseDto propertyResponseDto = modelMapper.map(property, PropertyResponseDto.class);
         List<AvailabilityEntryDto> availabilityEntryDtos = property.getAvailabilityEntries().stream()

--- a/src/main/java/com/lunark/lunark/properties/controller/PropertyController.java
+++ b/src/main/java/com/lunark/lunark/properties/controller/PropertyController.java
@@ -166,7 +166,8 @@ public class PropertyController {
     @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAuthority('HOST')")
     public ResponseEntity<PropertyResponseDto> updateProperty(@RequestBody @Valid PropertyRequestDto propertyDto) {
-        Property property = propertyDtoMapper.fromDtoToProperty(propertyDto);
+        Account host = (Account) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Property property = propertyDtoMapper.fromDtoToProperty(propertyDto, host.getId());
         if (this.propertyService.find(property.getId()).isEmpty())  {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/src/main/java/com/lunark/lunark/properties/controller/PropertyController.java
+++ b/src/main/java/com/lunark/lunark/properties/controller/PropertyController.java
@@ -1,5 +1,6 @@
 package com.lunark.lunark.properties.controller;
 
+import com.lunark.lunark.auth.model.Account;
 import com.lunark.lunark.mapper.PropertyDtoMapper;
 import com.lunark.lunark.properties.dto.AvailabilityEntryDto;
 import com.lunark.lunark.properties.dto.PropertyRequestDto;
@@ -22,6 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -154,8 +156,9 @@ public class PropertyController {
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAuthority('HOST')")
-    public ResponseEntity<PropertyResponseDto> createProperty(@Valid @RequestBody PropertyRequestDto propertyDto) {
-        Property property = propertyService.create(propertyDtoMapper.fromDtoToProperty(propertyDto));
+    public ResponseEntity<PropertyResponseDto> createProperty(@RequestBody PropertyRequestDto propertyDto) {
+        Account host = (Account) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Property property = propertyService.create(propertyDtoMapper.fromDtoToProperty(propertyDto, host.getId()));
         PropertyResponseDto response = PropertyDtoMapper.fromPropertyToDto(property);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/com/lunark/lunark/properties/dto/PropertyRequestDto.java
+++ b/src/main/java/com/lunark/lunark/properties/dto/PropertyRequestDto.java
@@ -50,7 +50,6 @@ public class PropertyRequestDto {
     @NotNull
     Property.PropertyType type;
     @PositiveOrZero
-    @HostExistsConstraint
     Long hostId;
     @Min(-90)
     @Max(90)


### PR DESCRIPTION
This PR changes property addition and editing to get the id of the host of a property based on the authentication token instead of the `hostId` sent in the request body.