### PR TITLE
Add stomp endpoint that does not use SockJS

### DIFF
--- a/src/main/java/com/lunark/lunark/configuration/WebSocketConfiguration.java
+++ b/src/main/java/com/lunark/lunark/configuration/WebSocketConfiguration.java
@@ -40,6 +40,8 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
         registry.addEndpoint("/api/socket")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
+        registry.addEndpoint("/api/non-sockjs-socket")
+                .setAllowedOriginPatterns("*");
     }
 
     @Override


### PR DESCRIPTION
This PR registers a new STOMP endpoint, which does not use SockJS, so the mobile client can connect to the server.