### PR TITLE
Property search sort order

### DIFF
--- a/src/main/java/com/lunark/lunark/properties/controller/PropertyController.java
+++ b/src/main/java/com/lunark/lunark/properties/controller/PropertyController.java
@@ -61,7 +61,8 @@ public class PropertyController {
             @RequestParam(required = false) List<@PositiveOrZero Long> amenityIds,
             @RequestParam(required = false) Property.PropertyType type,
             @RequestParam(required = false) @Positive(message = "Min price must be positive") Double minPrice,
-            @RequestParam(required = false) @Positive(message = "Max price must be positive") Double maxPrice
+            @RequestParam(required = false) @Positive(message = "Max price must be positive") Double maxPrice,
+            @RequestParam(required = false) @Pattern(message = "Must be ASC or DESC", regexp = "^ASC$|^DESC$") String sort
     ) {
 
         PropertySearchDto filter = PropertySearchDto.builder()
@@ -74,6 +75,7 @@ public class PropertyController {
                 .minPrice(minPrice)
                 .maxPrice(maxPrice)
                 .amenityIds(amenityIds)
+                .sort(sort)
                 .build();
 
         List<Property> properties = propertyService.findByFilter(filter);

--- a/src/main/java/com/lunark/lunark/properties/dto/PropertySearchDto.java
+++ b/src/main/java/com/lunark/lunark/properties/dto/PropertySearchDto.java
@@ -19,4 +19,5 @@ public class PropertySearchDto {
     Property.PropertyType type;
     Double minPrice;
     Double maxPrice;
+    String sort;
 }

--- a/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
+++ b/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
@@ -114,10 +114,14 @@ public class PropertySpecification implements Specification<Property> {
         }
 
         Order order;
+        Subquery<LocalDate> subquery = query.subquery(LocalDate.class);
+        Root<Property> subRoot = subquery.correlate(root);
+        Join<Property, PropertyAvailabilityEntry> entryJoin = subRoot.join("availabilityEntries");
+        subquery.select(entryJoin.get("date"));
         if (filter.getSort() == null || filter.getSort().equals("ASC")) {
-            order = criteriaBuilder.asc(root.get("name"));
+            order = criteriaBuilder.asc(subquery);
         } else {
-            order = criteriaBuilder.desc(root.get("name"));
+            order = criteriaBuilder.desc(subquery);
         }
         query.orderBy(order);
 

--- a/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
+++ b/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
@@ -113,6 +113,14 @@ public class PropertySpecification implements Specification<Property> {
             predicate = criteriaBuilder.and(predicate, typePredicate);
         }
 
+        Order order;
+        if (filter.getSort() == null || filter.getSort().equals("ASC")) {
+            order = criteriaBuilder.asc(root.get("name"));
+        } else {
+            order = criteriaBuilder.desc(root.get("name"));
+        }
+        query.orderBy(order);
+
         return predicate;
     }
 

--- a/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
+++ b/src/main/java/com/lunark/lunark/properties/specification/PropertySpecification.java
@@ -5,7 +5,6 @@ import com.lunark.lunark.properties.dto.PropertySearchDto;
 import com.lunark.lunark.properties.model.Property;
 import com.lunark.lunark.properties.model.PropertyAvailabilityEntry;
 import jakarta.persistence.criteria.*;
-import org.hibernate.sql.ast.spi.ExpressionReplacementWalker;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;


### PR DESCRIPTION
Adds optional sort order query param when searching properties. By default properties are sorted alphabetically by name.