### PR TITLE
Don't lose notification settings when updating account

### DIFF
--- a/src/main/java/com/lunark/lunark/auth/service/AccountService.java
+++ b/src/main/java/com/lunark/lunark/auth/service/AccountService.java
@@ -81,6 +81,10 @@ public class AccountService implements IAccountService {
         if (oldAccount.getProfileImage() != null) {
             account.setProfileImage(oldAccount.getProfileImage());
         }
+        if (account.getHostNotificationSettings() == null && account.getGuestNotificationSettings() == null) {
+            account.setGuestNotificationSettings(oldAccount.getGuestNotificationSettings());
+            account.setHostNotificationSettings(oldAccount.getHostNotificationSettings());
+        }
         return accountRepository.saveAndFlush(account);
     }
 


### PR DESCRIPTION
This PR fixes the bug which caused all notification settings to be set to null when the user updated their profile.