### PR TITLE
Remove property approval if certain fields change

### DIFF
--- a/src/main/java/com/lunark/lunark/properties/model/Address.java
+++ b/src/main/java/com/lunark/lunark/properties/model/Address.java
@@ -7,12 +7,14 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Address{
     @NotNull
     @NotBlank


### PR DESCRIPTION
This PR changes property editing so that the property needs to be approved again by an admin if anything unrelated to pricing or availability is changed.